### PR TITLE
Fix raycast collision tolerance

### DIFF
--- a/include/raycast.h
+++ b/include/raycast.h
@@ -71,7 +71,7 @@ public:
         const float grid, const float grid_search)
     {
       kdtree_ = kdtree;
-      length_ = (end - begin).norm() / grid - 1;
+      length_ = (end - begin).norm() / grid_search - sqrtf(2.0);
       inc_ = (end - begin) / length_;
       pos_ = begin + inc_;
       count_ = 1;


### PR DESCRIPTION
Tolerance of the end of the raycast was too small in 1a758c0
because of the increase of the search range.