### PR TITLE
Refactor math functions

### DIFF
--- a/include/mcl_3dl/filter.h
+++ b/include/mcl_3dl/filter.h
@@ -97,12 +97,6 @@ public:
     return out_;
   }
 };
-
-template <int N>
-class FilterNd
-{
-public:
-};
 }  // namespace mcl_3dl
 
 #endif  // MCL_3DL_FILTER_H

--- a/include/mcl_3dl/filter.h
+++ b/include/mcl_3dl/filter.h
@@ -45,46 +45,41 @@ public:
   };
 
 protected:
-  type_t type_;
-  float time_const_;
+  bool angle_;
   float x_;
   float out_;
   float k_[4];
-  bool angle_;
 
 public:
-  Filter(const enum type_t type, const float tc, const float out0, const bool angle = false)
+  inline Filter(const enum type_t type, const float time_const, const float out0, const bool angle = false)
+    : angle_(angle)
+    , out_(out0)
   {
-    angle_ = angle;
-    time_const_ = tc;
-    type_ = type;
-    switch (type_)
+    switch (type)
     {
       case FILTER_LPF:
-        k_[3] = -1 / (1.0 + 2 * time_const_);
+        k_[3] = -1 / (1.0 + 2 * time_const);
         k_[2] = -k_[3];
-        k_[1] = (1.0 - 2 * time_const_) * k_[3];
+        k_[1] = (1.0 - 2 * time_const) * k_[3];
         k_[0] = -k_[1] - 1.0;
         x_ = (1 - k_[2]) * out0 / k_[3];
         break;
       case FILTER_HPF:
-        k_[3] = -1 / (1.0 + 2 * time_const_);
-        k_[2] = -k_[3] * 2 * time_const_;
-        k_[1] = (1.0 - 2 * time_const_) * k_[3];
-        k_[0] = 2 * time_const_ * (-k_[1] + 1.0);
+        k_[3] = -1 / (1.0 + 2 * time_const);
+        k_[2] = -k_[3] * 2 * time_const;
+        k_[1] = (1.0 - 2 * time_const) * k_[3];
+        k_[0] = 2 * time_const * (-k_[1] + 1.0);
         x_ = (1 - k_[2]) * out0 / k_[3];
         break;
     }
-    out_ = out0;
   }
-  void set(const float& out0)
+  inline void set(const float out0)
   {
     x_ = (1 - k_[2]) * out0 / k_[3];
     out_ = out0;
   }
-  float in(const float& i)
+  inline float in(float in)
   {
-    float in = i;
     assert(std::isfinite(in));
 
     if (angle_)
@@ -97,10 +92,16 @@ public:
     assert(std::isfinite(out_));
     return out_;
   }
-  float get()
+  inline float get() const
   {
     return out_;
   }
+};
+
+template <int N>
+class FilterNd
+{
+public:
 };
 }  // namespace mcl_3dl
 

--- a/include/mcl_3dl/quat.h
+++ b/include/mcl_3dl/quat.h
@@ -45,18 +45,18 @@ public:
   float z_;
   float w_;
 
-  Quat(const float& x, const float& y, const float& z, const float& w)
+  inline constexpr Quat(const float& x, const float& y, const float& z, const float& w)
+    : x_(x)
+    , y_(y)
+    , z_(z)
+    , w_(w)
   {
-    x_ = x;
-    y_ = y;
-    z_ = z;
-    w_ = w;
   }
-  Quat(const Vec3& axis, const float& ang)
+  inline Quat(const Vec3& axis, const float& ang)
   {
     setAxisAng(axis, ang);
   }
-  Quat(const Vec3& forward, const Vec3& up_raw)
+  inline Quat(const Vec3& forward, const Vec3& up_raw)
   {
     const Vec3 xv = forward.normalized();
     const Vec3 yv = up_raw.cross(xv).normalized();
@@ -73,36 +73,38 @@ public:
     if (yv.x_ - xv.y_ > 0)
       z_ = -z_;
   }
-  explicit Quat(const Vec3& rpy)
+  inline explicit Quat(const Vec3& rpy)
   {
     setRPY(rpy);
   }
-  Quat()
+  inline constexpr Quat()
+    : x_(0)
+    , y_(0)
+    , z_(0)
+    , w_(1)
   {
-    w_ = 1.0;
-    x_ = y_ = z_ = 0.0;
   }
-  float dot(const Quat& q) const
+  inline constexpr float dot(const Quat& q) const
   {
     return x_ * q.x_ + y_ * q.y_ + z_ * q.z_ + w_ * q.w_;
   }
-  float norm() const
+  inline float norm() const
   {
     return std::sqrt(dot(*this));
   }
-  bool operator==(const Quat& q) const
+  inline constexpr bool operator==(const Quat& q) const
   {
     return x_ == q.x_ && y_ == q.y_ && z_ == q.z_ && w_ == q.w_;
   }
-  bool operator!=(const Quat& q) const
+  inline constexpr bool operator!=(const Quat& q) const
   {
     return !operator==(q);
   }
-  Quat operator+(const Quat& q) const
+  inline Quat operator+(const Quat& q) const
   {
     return Quat(x_ + q.x_, y_ + q.y_, z_ + q.z_, w_ + q.w_);
   }
-  Quat operator+=(const Quat& q)
+  inline Quat operator+=(const Quat& q)
   {
     x_ += q.x_;
     y_ += q.y_;
@@ -110,11 +112,11 @@ public:
     w_ += q.w_;
     return *this;
   }
-  Quat operator-(const Quat& q) const
+  inline Quat operator-(const Quat& q) const
   {
     return Quat(x_ - q.x_, y_ - q.y_, z_ - q.z_, w_ - q.w_);
   }
-  Quat operator-=(const Quat& q)
+  inline Quat operator-=(const Quat& q)
   {
     x_ -= q.x_;
     y_ -= q.y_;
@@ -122,11 +124,11 @@ public:
     w_ -= q.w_;
     return *this;
   }
-  Quat operator-() const
+  inline constexpr Quat operator-() const
   {
     return Quat(-x_, -y_, -z_, -w_);
   }
-  Quat operator*(const Quat& q) const
+  inline constexpr Quat operator*(const Quat& q) const
   {
     return Quat(
         w_ * q.x_ + x_ * q.w_ + y_ * q.z_ - z_ * q.y_,
@@ -134,20 +136,20 @@ public:
         w_ * q.z_ + z_ * q.w_ + x_ * q.y_ - y_ * q.x_,
         w_ * q.w_ - x_ * q.x_ - y_ * q.y_ - z_ * q.z_);
   }
-  Vec3 operator*(const Vec3& v) const
+  inline Vec3 operator*(const Vec3& v) const
   {
     const Quat ret = *this * Quat(v.x_, v.y_, v.z_, 0.0) * conj();
     return Vec3(ret.x_, ret.y_, ret.z_);
   }
-  Quat operator*(const float& s) const
+  inline constexpr Quat operator*(const float& s) const
   {
     return Quat(x_ * s, y_ * s, z_ * s, w_ * s);
   }
-  Quat operator/(const float& s) const
+  inline constexpr Quat operator/(const float& s) const
   {
     return operator*(1.0 / s);
   }
-  Quat operator*=(const float& s)
+  inline Quat operator*=(const float& s)
   {
     x_ *= s;
     y_ *= s;
@@ -155,7 +157,7 @@ public:
     w_ *= s;
     return *this;
   }
-  Quat operator/=(const float& s)
+  inline Quat operator/=(const float& s)
   {
     x_ /= s;
     y_ /= s;
@@ -163,76 +165,65 @@ public:
     w_ /= s;
     return *this;
   }
-  Quat weighted(const float& s) const
+  inline Quat weighted(const float& s) const
   {
     Vec3 axis;
     float ang;
     getAxisAng(axis, ang);
     return Quat(axis, ang * s);
   }
-  Quat normalized() const
+  inline Quat normalized() const
   {
-    float n = norm();
-    Quat ret = *this;
-    ret.x_ /= n;
-    ret.y_ /= n;
-    ret.z_ /= n;
-    ret.w_ /= n;
-    return ret;
+    return (*this) / norm();
   }
-  void normalize()
+  inline void normalize()
   {
     *this = normalized();
   }
-  Quat conj() const
+  inline constexpr Quat conj() const
   {
     return Quat(-x_, -y_, -z_, w_);
   }
-  Quat inv() const
+  inline constexpr Quat inv() const
   {
     return conj() / dot(*this);
   }
-  Vec3 getRPY() const
+  inline constexpr Vec3 getRPY() const
   {
     const float ysq = y_ * y_;
     const float t0 = -2.0 * (ysq + z_ * z_) + 1.0;
     const float t1 = +2.0 * (x_ * y_ + w_ * z_);
-    float t2 = -2.0 * (x_ * z_ - w_ * y_);
+    const float t2 = std::max(-1.0, std::min(1.0, -2.0 * (x_ * z_ - w_ * y_)));
     const float t3 = +2.0 * (y_ * z_ + w_ * x_);
     const float t4 = -2.0 * (x_ * x_ + ysq) + 1.0;
 
-    if (t2 > 1.0)
-      t2 = 1.0;
-    if (t2 < -1.0)
-      t2 = -1.0;
-
     return Vec3(std::atan2(t3, t4), std::asin(t2), std::atan2(t1, t0));
   }
-  void setRPY(const Vec3& rpy)
+  inline void setRPY(const Vec3& rpy)
   {
-    const float t2 = cos(rpy.x_ * 0.5);
-    const float t3 = sin(rpy.x_ * 0.5);
-    const float t4 = cos(rpy.y_ * 0.5);
-    const float t5 = sin(rpy.y_ * 0.5);
-    const float t0 = cos(rpy.z_ * 0.5);
-    const float t1 = sin(rpy.z_ * 0.5);
+    const float t2 = std::cos(rpy.x_ / 2);
+    const float t3 = std::sin(rpy.x_ / 2);
+    const float t4 = std::cos(rpy.y_ / 2);
+    const float t5 = std::sin(rpy.y_ / 2);
+    const float t0 = std::cos(rpy.z_ / 2);
+    const float t1 = std::sin(rpy.z_ / 2);
 
     x_ = t0 * t3 * t4 - t1 * t2 * t5;
     y_ = t0 * t2 * t5 + t1 * t3 * t4;
     z_ = t1 * t2 * t4 - t0 * t3 * t5;
     w_ = t0 * t2 * t4 + t1 * t3 * t5;
   }
-  void setAxisAng(const Vec3& axis, const float& ang)
+  inline void setAxisAng(const Vec3& axis, const float& ang)
   {
     const Vec3 a = axis / axis.norm();
-    const float s = sinf(ang / 2.0);
+    const float s = std::sin(ang / 2);
     x_ = a.x_ * s;
     y_ = a.y_ * s;
     z_ = a.z_ * s;
-    w_ = cosf(ang / 2.0);
+    w_ = std::cos(ang / 2);
     normalize();
   }
-  void getAxisAng(Vec3& axis, float& ang) const
+  inline void getAxisAng(Vec3& axis, float& ang) const
   {
     if (fabs(w_) >= 1.0 - 0.000001)
     {
@@ -240,13 +231,13 @@ public:
       axis = Vec3(0.0, 0.0, 1.0);
       return;
     }
-    ang = acosf(w_) * 2.0;
+    ang = std::acos(w_) * 2.0;
     if (ang > M_PI)
       ang -= 2.0 * M_PI;
     const float wsq = 1.0 - w_ * w_;
     axis = Vec3(x_, y_, z_) / std::sqrt(wsq);
   }
-  void rotateAxis(const Quat& r)
+  inline void rotateAxis(const Quat& r)
   {
     Vec3 axis;
     float ang;

--- a/include/mcl_3dl/vec3.h
+++ b/include/mcl_3dl/vec3.h
@@ -40,35 +40,19 @@ public:
   float x_;
   float y_;
   float z_;
-  Vec3(const float x, const float y, const float z)
+  inline constexpr Vec3(const float x, const float y, const float z)
+    : x_(x)
+    , y_(y)
+    , z_(z)
   {
-    x_ = x;
-    y_ = y;
-    z_ = z;
   }
-  Vec3()
+  inline constexpr Vec3()
+    : x_(0)
+    , y_(0)
+    , z_(0)
   {
-    x_ = y_ = z_ = 0.0;
   }
-  float& operator[](const size_t i)
-  {
-    switch (i)
-    {
-      case 0:
-        return x_;
-        break;
-      case 1:
-        return y_;
-        break;
-      case 2:
-        return z_;
-        break;
-      default:
-        break;
-    }
-    return x_;
-  }
-  float operator[](const size_t i) const
+  inline float& operator[](const size_t i)
   {
     switch (i)
     {
@@ -86,73 +70,91 @@ public:
     }
     return x_;
   }
-  bool operator==(const Vec3& q) const
+  inline float operator[](const size_t i) const
+  {
+    switch (i)
+    {
+      case 0:
+        return x_;
+        break;
+      case 1:
+        return y_;
+        break;
+      case 2:
+        return z_;
+        break;
+      default:
+        break;
+    }
+    return x_;
+  }
+  inline constexpr bool operator==(const Vec3& q) const
   {
     return x_ == q.x_ && y_ == q.y_ && z_ == q.z_;
   }
-  bool operator!=(const Vec3& q) const
+  inline constexpr bool operator!=(const Vec3& q) const
   {
     return !operator==(q);
   }
-  Vec3 operator+(const Vec3& q) const
+  inline constexpr Vec3 operator+(const Vec3& q) const
   {
     return Vec3(x_ + q.x_, y_ + q.y_, z_ + q.z_);
   }
-  Vec3 operator-(const Vec3& q) const
+  inline constexpr Vec3 operator-(const Vec3& q) const
   {
     return Vec3(x_ - q.x_, y_ - q.y_, z_ - q.z_);
   }
-  Vec3 operator-() const
+  inline constexpr Vec3 operator-() const
   {
     return Vec3(-x_, -y_, -z_);
   }
-  Vec3 operator*(const float& s) const
+  inline constexpr Vec3 operator*(const float s) const
   {
     return Vec3(x_ * s, y_ * s, z_ * s);
   }
-  Vec3 operator/(const float& s) const
+  inline constexpr Vec3 operator/(const float s) const
   {
     return Vec3(x_ / s, y_ / s, z_ / s);
   }
-  Vec3& operator+=(const Vec3& q)
+  inline Vec3& operator+=(const Vec3& q)
   {
     *this = *this + q;
     return *this;
   }
-  Vec3& operator-=(const Vec3& q)
+  inline Vec3& operator-=(const Vec3& q)
   {
     *this = *this - q;
     return *this;
   }
-  Vec3& operator*=(const float& s)
+  inline Vec3& operator*=(const float& s)
   {
     *this = *this * s;
     return *this;
   }
-  Vec3& operator/=(const float& s)
+  inline Vec3& operator/=(const float& s)
   {
     *this = *this / s;
     return *this;
   }
-  float dot(const Vec3& q) const
+  inline constexpr float dot(const Vec3& q) const
   {
     return x_ * q.x_ + y_ * q.y_ + z_ * q.z_;
   }
-  Vec3 cross(const Vec3& q) const
+  inline constexpr Vec3 cross(const Vec3& q) const
   {
     return Vec3(y_ * q.z_ - z_ * q.y_,
                 z_ * q.x_ - x_ * q.z_,
                 x_ * q.y_ - y_ * q.x_);
   }
-  Vec3 times(const Vec3& q) const
+  inline constexpr Vec3 times(const Vec3& q) const
   {
     return Vec3(x_ * q.x_, y_ * q.y_, z_ * q.z_);
   }
-  float norm() const
+  inline float norm() const
   {
     return std::sqrt(dot(*this));
   }
-  Vec3 normalized() const
+  inline Vec3 normalized() const
   {
     return *this / norm();
   }


### PR DESCRIPTION
Give constexpr and inline attribute to math functions.
Use C++ math functions instead of C.