### PR TITLE
Add PointCloudSamplerWithNormal

### DIFF
--- a/include/mcl_3dl/lidar_measurement_model_base.h
+++ b/include/mcl_3dl/lidar_measurement_model_base.h
@@ -41,6 +41,7 @@
 #include <pcl_ros/point_cloud.h>
 
 #include <mcl_3dl/chunked_kdtree.h>
+#include <mcl_3dl/point_cloud_random_sampler.h>
 #include <mcl_3dl/point_types.h>
 #include <mcl_3dl/state_6dof.h>
 #include <mcl_3dl/vec3.h>
@@ -64,6 +65,12 @@ class LidarMeasurementModelBase
 public:
   using Ptr = std::shared_ptr<LidarMeasurementModelBase>;
   using PointType = mcl_3dl::PointXYZIL;
+  using SamplerType = PointCloudRandomSampler<PointType>;
+
+  LidarMeasurementModelBase()
+    : sampler_()
+  {
+  }
 
   virtual void loadConfig(
       const ros::NodeHandle& nh,
@@ -80,6 +87,18 @@ public:
       const pcl::PointCloud<PointType>::ConstPtr&,
       const std::vector<Vec3>&,
       const State6DOF&) const = 0;
+
+  void setRandomSampler(const std::shared_ptr<SamplerType>& sampler)
+  {
+    sampler_ = sampler;
+  }
+  std::shared_ptr<SamplerType> getRandomSampler()
+  {
+    return sampler_;
+  }
+
+protected:
+  std::shared_ptr<SamplerType> sampler_;
 };
 }  // namespace mcl_3dl
 

--- a/include/mcl_3dl/lidar_measurement_model_base.h
+++ b/include/mcl_3dl/lidar_measurement_model_base.h
@@ -42,6 +42,7 @@
 
 #include <mcl_3dl/chunked_kdtree.h>
 #include <mcl_3dl/point_cloud_random_sampler.h>
+#include <mcl_3dl/point_cloud_random_samplers/point_cloud_uniform_sampler.h>
 #include <mcl_3dl/point_types.h>
 #include <mcl_3dl/state_6dof.h>
 #include <mcl_3dl/vec3.h>
@@ -68,7 +69,7 @@ public:
   using SamplerType = PointCloudRandomSampler<PointType>;
 
   LidarMeasurementModelBase()
-    : sampler_()
+    : sampler_(new PointCloudUniformSampler<PointType>())
   {
   }
 

--- a/include/mcl_3dl/lidar_measurement_models/lidar_measurement_model_beam.h
+++ b/include/mcl_3dl/lidar_measurement_models/lidar_measurement_model_beam.h
@@ -64,8 +64,6 @@ private:
   float map_grid_max_;
   uint32_t filter_label_max_;
 
-  PointCloudRandomSampler sampler_;
-
 public:
   LidarMeasurementModelBeam(const float x, const float y, const float z);
 

--- a/include/mcl_3dl/lidar_measurement_models/lidar_measurement_model_likelihood.h
+++ b/include/mcl_3dl/lidar_measurement_models/lidar_measurement_model_likelihood.h
@@ -61,8 +61,6 @@ private:
   float match_dist_min_;
   float match_dist_flat_;
 
-  PointCloudRandomSampler sampler_;
-
 public:
   inline float getMaxSearchRange() const
   {

--- a/include/mcl_3dl/parameters.h
+++ b/include/mcl_3dl/parameters.h
@@ -107,6 +107,7 @@ public:
   std::array<float, 3> std_warn_thresh_;
   State6DOF initial_pose_;
   State6DOF initial_pose_std_;
+  bool use_random_sampler_with_normal_;
 };
 }  // namespace mcl_3dl
 

--- a/include/mcl_3dl/point_cloud_random_samplers/point_cloud_sampler_with_normal.h
+++ b/include/mcl_3dl/point_cloud_random_samplers/point_cloud_sampler_with_normal.h
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2020, the mcl_3dl authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its 
+ *       contributors may be used to endorse or promote products derived from 
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MCL_3DL_POINT_CLOUD_RANDOM_SAMPLERS_POINT_CLOUD_SAMPLER_WITH_NORMAL_H
+#define MCL_3DL_POINT_CLOUD_RANDOM_SAMPLERS_POINT_CLOUD_SAMPLER_WITH_NORMAL_H
+
+#include <memory>
+#include <random>
+#include <unordered_set>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Eigenvalues>
+
+#include <pcl/features/normal_3d.h>
+#include <pcl/kdtree/kdtree_flann.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <ros/ros.h>
+
+#include <mcl_3dl/point_cloud_random_sampler.h>
+#include <mcl_3dl/state_6dof.h>
+
+namespace mcl_3dl
+{
+template <class POINT_TYPE>
+class PointCloudSamplerWithNormal : public PointCloudRandomSampler<POINT_TYPE>
+{
+private:
+  using Matrix = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
+  using Vector = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+
+  std::shared_ptr<std::default_random_engine> engine_;
+  State6DOF mean_;
+  Matrix eigen_vectors_;
+  Vector eigen_values_;
+  double perform_weighting_ratio_;
+  double max_weight_ratio_;
+  double max_weight_;
+  double normal_search_range_;
+
+public:
+  explicit PointCloudSamplerWithNormal(const unsigned int random_seed = std::random_device()())
+    : engine_(std::make_shared<std::default_random_engine>(random_seed))
+    , perform_weighting_ratio_(2.0)
+    , max_weight_ratio_(5.0)
+    , max_weight_(10.0)
+    , normal_search_range_(0.4)
+  {
+  }
+
+  void loadConfig(const ros::NodeHandle& nh)
+  {
+    ros::NodeHandle pnh(nh, "random_sampler_with_normal");
+    pnh.param("perform_weighting_ratio", perform_weighting_ratio_, 2.0);
+    pnh.param("max_weight_ratio", max_weight_ratio_, 5.0);
+    pnh.param("max_weight", max_weight_, 5.0);
+    pnh.param("normal_search_range", normal_search_range_, 0.4);
+  }
+
+  void setParameters(const double perform_weighting_ratio, const double max_weight_ratio,
+                     const double max_weight, const double normal_search_range)
+  {
+    perform_weighting_ratio_ = perform_weighting_ratio;
+    max_weight_ratio_ = max_weight_ratio;
+    max_weight_ = max_weight;
+    normal_search_range_ = normal_search_range;
+  }
+
+  void setParticleStatistics(const State6DOF& mean, const std::vector<State6DOF>& covariances)
+  {
+    mean_ = mean;
+    Matrix pos_cov(3, 3);
+    for (size_t i = 0; i < 3; ++i)
+    {
+      for (size_t j = 0; j < 3; ++j)
+      {
+        pos_cov(i, j) = std::abs(covariances[i][j]);
+      }
+    }
+    const Eigen::SelfAdjointEigenSolver<Matrix> eigen_solver(pos_cov);
+    eigen_vectors_ = eigen_solver.eigenvectors();
+    eigen_values_ = eigen_solver.eigenvalues();
+  }
+
+  typename pcl::PointCloud<POINT_TYPE>::Ptr sample(
+      const typename pcl::PointCloud<POINT_TYPE>::ConstPtr& pc,
+      const size_t num) const final
+  {
+    const ros::WallTime start_timestamp = ros::WallTime::now();
+
+    typename pcl::PointCloud<POINT_TYPE>::Ptr output(new pcl::PointCloud<POINT_TYPE>);
+    output->header = pc->header;
+
+    if (pc->points.size() == 0)
+    {
+      return output;
+    }
+    if (pc->size() <= num)
+    {
+      *output = *pc;
+      return output;
+    }
+
+    const double eigen_value_ratio = std::sqrt(eigen_values_[2]) / std::sqrt(eigen_values_[1]);
+
+    double max_weight = 1.0;
+    if (eigen_value_ratio < perform_weighting_ratio_)
+    {
+      max_weight = 1.0;
+    }
+    else if (eigen_value_ratio > max_weight_ratio_)
+    {
+      max_weight = max_weight_;
+    }
+    else
+    {
+      const double weight_ratio =
+          (eigen_value_ratio - perform_weighting_ratio_) / (max_weight_ratio_ - perform_weighting_ratio_);
+      max_weight = 1.0 + (max_weight_ - 1.0) * weight_ratio;
+    }
+    const mcl_3dl::Vec3 fpc_global(eigen_vectors_(0, 2), eigen_vectors_(1, 2), eigen_vectors_(2, 2));
+    const mcl_3dl::Vec3 fpc_local = mean_.rot_.inv() * fpc_global;
+    pcl::NormalEstimation<POINT_TYPE, pcl::Normal> ne;
+    pcl::PointCloud<pcl::Normal>::Ptr cloud_normals(new pcl::PointCloud<pcl::Normal>);
+    typename pcl::search::KdTree<POINT_TYPE>::Ptr tree(new pcl::search::KdTree<POINT_TYPE>());
+    ne.setInputCloud(pc);
+    ne.setSearchMethod(tree);
+    ne.setRadiusSearch(normal_search_range_);
+    ne.compute(*cloud_normals);
+
+    const ros::WallTime compute_normal_timestamp = ros::WallTime::now();
+    std::vector<double> cumulative_weight(cloud_normals->points.size(), 0.0);
+    for (size_t i = 0; i < cloud_normals->points.size(); i++)
+    {
+      double weight = 1.0;
+      const auto& normal = cloud_normals->points[i];
+      if (!std::isnan(normal.normal_x) && !std::isnan(normal.normal_y) && !std::isnan(normal.normal_z))
+      {
+        double acos_angle = std::abs(normal.normal_x * fpc_local.x_ +
+                                     normal.normal_y * fpc_local.y_ +
+                                     normal.normal_z * fpc_local.z_);
+        // Avoid that std::acos() returns nan because of calculation errors
+        if (acos_angle > 1.0)
+        {
+          acos_angle = 1.0;
+        }
+        const double angle = std::acos(acos_angle);
+        weight = 1.0 + (max_weight - 1.0) * ((M_PI / 2 - angle) / (M_PI / 2));
+        if (std::isnan(weight))
+        {
+          ROS_ERROR("Something is wrong: %f, %f, %f, %f, %f", angle, normal.normal_x,
+                    normal.normal_y, normal.normal_z, normal.normal_x * eigen_vectors_(0, 2) +
+                                                          normal.normal_y * eigen_vectors_(1, 2) +
+                                                          normal.normal_z * eigen_vectors_(2, 2));
+          weight = 1.0;
+        }
+      }
+      cumulative_weight[i] = weight + ((i == 0) ? 0.0 : cumulative_weight[i - 1]);
+    }
+    std::uniform_real_distribution<double> ud(0, cumulative_weight.back());
+    // Use unordered_set to avoid duplication
+    std::unordered_set<size_t> selected_ids;
+    while (true)
+    {
+      const double random_value = ud(*engine_);
+      auto it = std::lower_bound(cumulative_weight.begin(), cumulative_weight.end(), random_value);
+      const size_t n = it - cumulative_weight.begin();
+      selected_ids.insert(n);
+      if (selected_ids.size() >= num)
+      {
+        break;
+      }
+    }
+    output->points.reserve(num);
+    for (const auto& index : selected_ids)
+    {
+      output->push_back(pc->points[index]);
+    }
+
+    const ros::WallTime final_timestamp = ros::WallTime::now();
+    ROS_DEBUG("PointCloudSamplerWithNormal::sample() computation time: %f[s] (Normal calculation: %f[s])",
+              (final_timestamp - start_timestamp).toSec(), (compute_normal_timestamp - start_timestamp).toSec());
+    ROS_DEBUG("Chosen eigen vector: (%f, %f, %f), max weight: %f",
+              eigen_vectors_(0, 2), eigen_vectors_(1, 2), eigen_vectors_(2, 2), max_weight);
+
+    return output;
+  }
+};
+
+}  // namespace mcl_3dl
+
+#endif  // MCL_3DL_POINT_CLOUD_RANDOM_SAMPLERS_POINT_CLOUD_SAMPLER_WITH_NORMAL_H

--- a/include/mcl_3dl/point_cloud_random_samplers/point_cloud_sampler_with_normal.h
+++ b/include/mcl_3dl/point_cloud_random_samplers/point_cloud_sampler_with_normal.h
@@ -173,14 +173,6 @@ public:
         }
         const double angle = std::acos(acos_angle);
         weight = 1.0 + (max_weight - 1.0) * ((M_PI / 2 - angle) / (M_PI / 2));
-        if (std::isnan(weight))
-        {
-          ROS_ERROR("Something is wrong: %f, %f, %f, %f, %f", angle, normal.normal_x,
-                    normal.normal_y, normal.normal_z, normal.normal_x * eigen_vectors_(0, 2) +
-                                                          normal.normal_y * eigen_vectors_(1, 2) +
-                                                          normal.normal_z * eigen_vectors_(2, 2));
-          weight = 1.0;
-        }
       }
       cumulative_weight[i] = weight + ((i == 0) ? 0.0 : cumulative_weight[i - 1]);
     }

--- a/include/mcl_3dl/point_cloud_random_samplers/point_cloud_sampler_with_normal.h
+++ b/include/mcl_3dl/point_cloud_random_samplers/point_cloud_sampler_with_normal.h
@@ -128,7 +128,7 @@ public:
       return output;
     }
 
-    const double eigen_value_ratio = std::sqrt(eigen_values_[2]) / std::sqrt(eigen_values_[1]);
+    const double eigen_value_ratio = std::sqrt(eigen_values_[2] / eigen_values_[1]);
 
     double max_weight = 1.0;
     if (eigen_value_ratio < perform_weighting_ratio_)
@@ -201,7 +201,6 @@ public:
               (final_timestamp - start_timestamp).toSec(), (compute_normal_timestamp - start_timestamp).toSec());
     ROS_DEBUG("Chosen eigen vector: (%f, %f, %f), max weight: %f",
               eigen_vectors_(0, 2), eigen_vectors_(1, 2), eigen_vectors_(2, 2), max_weight);
-
     return output;
   }
 };

--- a/include/mcl_3dl/point_cloud_random_samplers/point_cloud_uniform_sampler.h
+++ b/include/mcl_3dl/point_cloud_random_samplers/point_cloud_uniform_sampler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, the mcl_3dl authors
+ * Copyright (c) 2020, the mcl_3dl authors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,23 +27,51 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef MCL_3DL_POINT_CLOUD_RANDOM_SAMPLER_H
-#define MCL_3DL_POINT_CLOUD_RANDOM_SAMPLER_H
+#ifndef MCL_3DL_POINT_CLOUD_RANDOM_SAMPLERS_POINT_CLOUD_UNIFORM_SAMPLER_H
+#define MCL_3DL_POINT_CLOUD_RANDOM_SAMPLERS_POINT_CLOUD_UNIFORM_SAMPLER_H
+
+#include <memory>
+#include <random>
 
 #include <pcl/point_cloud.h>
 
-#include <mcl_3dl/chunked_kdtree.h>
+#include <mcl_3dl/point_cloud_random_sampler.h>
 
 namespace mcl_3dl
 {
 template <class POINT_TYPE>
-class PointCloudRandomSampler
+class PointCloudUniformSampler : public PointCloudRandomSampler<POINT_TYPE>
 {
+private:
+  std::random_device seed_gen_;
+  std::shared_ptr<std::default_random_engine> engine_;
+
 public:
-  virtual typename pcl::PointCloud<POINT_TYPE>::Ptr sample(
-      const typename pcl::PointCloud<POINT_TYPE>::ConstPtr& pc, const size_t num) const = 0;
+  PointCloudUniformSampler()
+    : engine_(new std::default_random_engine(seed_gen_()))
+  {
+  }
+  typename pcl::PointCloud<POINT_TYPE>::Ptr sample(
+      const typename pcl::PointCloud<POINT_TYPE>::ConstPtr& pc,
+      const size_t num) const final
+  {
+    typename pcl::PointCloud<POINT_TYPE>::Ptr output(new pcl::PointCloud<POINT_TYPE>);
+    output->header = pc->header;
+
+    if (pc->points.size() == 0)
+      return output;
+
+    output->points.reserve(num);
+    std::uniform_int_distribution<size_t> ud(0, pc->points.size() - 1);
+    for (size_t i = 0; i < num; i++)
+    {
+      output->push_back(pc->points[ud(*engine_)]);
+    }
+
+    return output;
+  }
 };
 
 }  // namespace mcl_3dl
 
-#endif  // MCL_3DL_POINT_CLOUD_RANDOM_SAMPLER_H
+#endif  // MCL_3DL_POINT_CLOUD_RANDOM_SAMPLERS_POINT_CLOUD_UNIFORM_SAMPLER_H

--- a/src/lidar_measurement_model_beam.cpp
+++ b/src/lidar_measurement_model_beam.cpp
@@ -131,7 +131,7 @@ LidarMeasurementModelBeam::filter(
   pc_filtered->width = 1;
   pc_filtered->height = pc_filtered->points.size();
 
-  return sampler_.sample<LidarMeasurementModelBase::PointType>(pc_filtered, num_points_);
+  return sampler_->sample(pc_filtered, num_points_);
 }
 
 LidarMeasurementResult LidarMeasurementModelBeam::measure(

--- a/src/lidar_measurement_model_likelihood.cpp
+++ b/src/lidar_measurement_model_likelihood.cpp
@@ -118,7 +118,7 @@ LidarMeasurementModelLikelihood::filter(
   pc_filtered->width = 1;
   pc_filtered->height = pc_filtered->points.size();
 
-  return sampler_.sample<LidarMeasurementModelBase::PointType>(pc_filtered, num_points_);
+  return sampler_->sample(pc_filtered, num_points_);
 }
 
 LidarMeasurementResult LidarMeasurementModelLikelihood::measure(

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -192,6 +192,8 @@ bool Parameters::load(ros::NodeHandle& pnh)
       Vec3(v_x, v_y, v_z),
       Vec3(v_roll, v_pitch, v_yaw));
 
+  pnh.param("use_random_sampler_with_normal", use_random_sampler_with_normal_, false);
+
   return true;
 }
 }  // namespace mcl_3dl

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,8 +26,8 @@ catkin_add_gtest(test_motion_prediction_model_differential_drive src/test_motion
 target_link_libraries(test_motion_prediction_model_differential_drive ${catkin_LIBRARIES})
 catkin_add_gtest(test_noise_generator src/test_noise_generator.cpp)
 target_link_libraries(test_noise_generator ${catkin_LIBRARIES})
-catkin_add_gtest(test_random_samplers src/test_random_samplers.cpp)
-target_link_libraries(test_random_samplers ${catkin_LIBRARIES})
+catkin_add_gtest(test_point_cloud_random_sampler_with_normal src/test_point_cloud_random_sampler_with_normal.cpp)
+target_link_libraries(test_point_cloud_random_sampler_with_normal ${catkin_LIBRARIES})
 
 add_executable(performance_raycast src/performance_raycast.cpp)
 target_link_libraries(performance_raycast ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${PCL_LIBRARIES})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,8 @@ catkin_add_gtest(test_motion_prediction_model_differential_drive src/test_motion
 target_link_libraries(test_motion_prediction_model_differential_drive ${catkin_LIBRARIES})
 catkin_add_gtest(test_noise_generator src/test_noise_generator.cpp)
 target_link_libraries(test_noise_generator ${catkin_LIBRARIES})
+catkin_add_gtest(test_random_samplers src/test_random_samplers.cpp)
+target_link_libraries(test_random_samplers ${catkin_LIBRARIES})
 
 add_executable(performance_raycast src/performance_raycast.cpp)
 target_link_libraries(performance_raycast ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${PCL_LIBRARIES})
@@ -69,7 +71,7 @@ if(MCL_3DL_EXTRA_TESTS)
   catkin_download_test_data(
       ${PROJECT_NAME}_short_test3.bag
       https://openspur.org/~atsushi.w/dataset/mcl_3dl/short_test3.bag
-      MD5 7f0f4a2c2c4d569c81cb972d7dc30ca0 
+      MD5 7f0f4a2c2c4d569c81cb972d7dc30ca0
       FILENAME test/short_test3.bag)
 
   catkin_download_test_data(
@@ -86,7 +88,7 @@ if(MCL_3DL_EXTRA_TESTS)
   add_executable(compare_pose
       src/compare_pose.cpp)
   target_link_libraries(compare_pose ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
-  add_dependencies(compare_pose 
+  add_dependencies(compare_pose
         ${PROJECT_NAME}_short_test3.bag
         ${PROJECT_NAME}_short_test_ref.topic
         mcl_3dl)
@@ -108,7 +110,7 @@ if(MCL_3DL_EXTRA_TESTS)
   add_rostest_gtest(compare_tf ${PROJECT_BINARY_DIR}/test/tests/tf_rostest.test
       src/compare_tf.cpp)
   target_link_libraries(compare_tf ${catkin_LIBRARIES})
-  add_dependencies(compare_tf 
+  add_dependencies(compare_tf
         ${PROJECT_NAME}_short_test3.bag
         ${PROJECT_NAME}_short_test_ref.topic
         mcl_3dl

--- a/test/src/test_point_cloud_random_sampler.cpp
+++ b/test/src/test_point_cloud_random_sampler.cpp
@@ -30,11 +30,11 @@
 #include <pcl/point_types.h>
 #include <pcl_ros/point_cloud.h>
 
-#include <mcl_3dl/point_cloud_random_sampler.h>
+#include <mcl_3dl/point_cloud_random_samplers/point_cloud_uniform_sampler.h>
 
 #include <gtest/gtest.h>
 
-TEST(PointCloudRandomSampler, Sampling)
+TEST(PointCloudUniformSampler, Sampling)
 {
   pcl::PointCloud<pcl::PointXYZ>::Ptr pc_input(new pcl::PointCloud<pcl::PointXYZ>);
   pc_input->width = 1;
@@ -53,11 +53,11 @@ TEST(PointCloudRandomSampler, Sampling)
     pc_input->push_back(pcl::PointXYZ(p_ref[0], p_ref[1], p_ref[2]));
   }
 
-  mcl_3dl::PointCloudRandomSampler sampler;
+  mcl_3dl::PointCloudUniformSampler<pcl::PointXYZ> sampler;
 
   for (size_t num = 1; num < 4; num++)
   {
-    pcl::PointCloud<pcl::PointXYZ>::Ptr pc_output = sampler.sample<pcl::PointXYZ>(pc_input, num);
+    pcl::PointCloud<pcl::PointXYZ>::Ptr pc_output = sampler.sample(pc_input, num);
 
     // Check header and number of the points
     ASSERT_EQ(pc_output->header.frame_id, pc_input->header.frame_id);
@@ -82,7 +82,7 @@ TEST(PointCloudRandomSampler, Sampling)
   }
 
   // Make sure that the sampler returns 0 point output for 0 point input
-  pcl::PointCloud<pcl::PointXYZ>::Ptr pc_output0 = sampler.sample<pcl::PointXYZ>(pc_input, 0);
+  pcl::PointCloud<pcl::PointXYZ>::Ptr pc_output0 = sampler.sample(pc_input, 0);
   ASSERT_EQ(pc_output0->points.size(), 0u);
 }
 

--- a/test/src/test_point_cloud_random_sampler_with_normal.cpp
+++ b/test/src/test_point_cloud_random_sampler_with_normal.cpp
@@ -165,10 +165,10 @@ TEST(PointCloudSamplerWithNormal, Sampling)
   sampler.setParticleStatistics(mean, cov_matrix);
   pcl::PointCloud<PointXYZIL>::Ptr invalid_cloud(new pcl::PointCloud<PointXYZIL>());
   // Empty cloud
-  EXPECT_EQ(0, sampler.sample(invalid_cloud, 100)->size());
+  EXPECT_EQ(0u, sampler.sample(invalid_cloud, 100)->size());
   // Point cloud size is smaller than requested sample number
   invalid_cloud->push_back(PointXYZIL());
-  EXPECT_EQ(1, sampler.sample(invalid_cloud, 100)->size());
+  EXPECT_EQ(1u, sampler.sample(invalid_cloud, 100)->size());
 }
 }  // namespace test
 }  // namespace mcl_3dl

--- a/test/src/test_point_cloud_random_sampler_with_normal.cpp
+++ b/test/src/test_point_cloud_random_sampler_with_normal.cpp
@@ -143,7 +143,7 @@ TEST(PointCloudSamplerWithNormal, Sampling)
     {
       sampler.setParameters(parameter.perform_weighting_ratio, parameter.max_weight_ratio, parameter.max_weight, 0.4);
       const pcl::PointCloud<PointXYZIL>::Ptr extracted_cloud = sampler.sample(pc, sample_num);
-      EXPECT_EQ(sample_num, extracted_cloud->size());
+      EXPECT_EQ(sample_num, static_cast<int>(extracted_cloud->size()));
       // count[0] : numbers of points chosen from the wall at right angles
       // count[1] : numbers of points chosen from the parallel wall
       std::vector<int> counts(2, 0);

--- a/test/src/test_point_cloud_random_sampler_with_normal.cpp
+++ b/test/src/test_point_cloud_random_sampler_with_normal.cpp
@@ -35,31 +35,12 @@
 #include <pcl/point_types.h>
 
 #include <mcl_3dl/point_cloud_random_samplers/point_cloud_sampler_with_normal.h>
-#include <mcl_3dl/point_cloud_random_samplers/point_cloud_uniform_sampler.h>
 #include <mcl_3dl/point_types.h>
 
 namespace mcl_3dl
 {
 namespace test
 {
-TEST(PointCloudUniformSampler, testSample)
-{
-  PointCloudUniformSampler<PointXYZIL> sampler;
-  pcl::PointCloud<PointXYZIL>::Ptr org_cloud(new pcl::PointCloud<PointXYZIL>());
-
-  const pcl::PointCloud<PointXYZIL>::Ptr empty_result = sampler.sample(org_cloud, 10);
-  ASSERT_EQ(0, empty_result->size());
-
-  for (int i = 0; i < 100; ++i)
-  {
-    PointXYZIL point;
-    point.x = static_cast<float>(i);
-    org_cloud->push_back(point);
-  }
-  const pcl::PointCloud<PointXYZIL>::Ptr result = sampler.sample(org_cloud, 10);
-  ASSERT_EQ(10, result->size());
-}
-
 std::vector<State6DOF> buildPoseCovarianceMatrix(const double yaw,
                                                  const double front_std_dev,
                                                  const double side_std_dev)
@@ -112,7 +93,7 @@ void buildWall(pcl::PointCloud<PointXYZIL>::Ptr result_points, double rotation_a
   result_points->insert(result_points->end(), points.begin(), points.end());
 }
 
-TEST(PointCloudSamplerWithNormal, testSample)
+TEST(PointCloudSamplerWithNormal, Sampling)
 {
   pcl::PointCloud<PointXYZIL>::Ptr pc(new pcl::PointCloud<PointXYZIL>());
   int wall_length = 20;

--- a/test/src/test_random_samplers.cpp
+++ b/test/src/test_random_samplers.cpp
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2020, the mcl_3dl authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its 
+ *       contributors may be used to endorse or promote products derived from 
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <vector>
+
+#include <pcl/point_types.h>
+
+#include <mcl_3dl/point_cloud_random_samplers/point_cloud_sampler_with_normal.h>
+#include <mcl_3dl/point_cloud_random_samplers/point_cloud_uniform_sampler.h>
+#include <mcl_3dl/point_types.h>
+
+namespace mcl_3dl
+{
+namespace test
+{
+TEST(PointCloudUniformSampler, testSample)
+{
+  PointCloudUniformSampler<PointXYZIL> sampler;
+  pcl::PointCloud<PointXYZIL>::Ptr org_cloud(new pcl::PointCloud<PointXYZIL>());
+
+  const pcl::PointCloud<PointXYZIL>::Ptr empty_result = sampler.sample(org_cloud, 10);
+  ASSERT_EQ(0, empty_result->size());
+
+  for (int i = 0; i < 100; ++i)
+  {
+    PointXYZIL point;
+    point.x = static_cast<float>(i);
+    org_cloud->push_back(point);
+  }
+  const pcl::PointCloud<PointXYZIL>::Ptr result = sampler.sample(org_cloud, 10);
+  ASSERT_EQ(10, result->size());
+}
+
+std::vector<State6DOF> buildPoseCovarianceMatrix(const double yaw,
+                                                 const double front_std_dev,
+                                                 const double side_std_dev)
+{
+  Eigen::Matrix2d vt;
+  vt(0, 0) = std::cos(yaw);
+  vt(0, 1) = -std::sin(yaw);
+  vt(1, 0) = std::sin(yaw);
+  vt(1, 1) = std::cos(yaw);
+  Eigen::Matrix2d m;
+  m(0, 0) = std::pow(front_std_dev, 2);
+  m(0, 1) = 0;
+  m(1, 0) = 0;
+  m(1, 1) = std::pow(side_std_dev, 2);
+  const Eigen::Matrix2d xv_cov = vt.transpose() * m * vt;
+
+  std::vector<State6DOF> result(6);
+  for (auto& state : result)
+  {
+    for (size_t i = 0; i < 6; ++i)
+    {
+      state[i] = 0.0;
+    }
+  }
+  result[0][0] = xv_cov(0, 0);
+  result[1][0] = xv_cov(1, 0);
+  result[0][1] = xv_cov(0, 1);
+  result[1][1] = xv_cov(1, 1);
+  return result;
+}
+
+void buildWall(pcl::PointCloud<PointXYZIL>::Ptr result_points, double rotation_angle, int wall_length)
+{
+  pcl::PointCloud<PointXYZIL> points;
+  for (int ny = 0; ny < wall_length; ++ny)
+  {
+    for (int nz = 0; nz < wall_length; ++nz)
+    {
+      PointXYZIL point;
+      point.x = 20.0;
+      point.y = (ny - wall_length / 2) * 0.05;
+      point.z = (nz - wall_length / 2) * 0.05;
+      point.label = 0;
+      point.intensity = 3000;
+      points.push_back(point);
+    }
+  }
+  const State6DOF s(mcl_3dl::Vec3(0, 0, 0), mcl_3dl::Quat(mcl_3dl::Vec3(0, 0, 1), rotation_angle));
+  s.transform(points);
+  result_points->insert(result_points->end(), points.begin(), points.end());
+}
+
+TEST(PointCloudSamplerWithNormal, testSample)
+{
+  pcl::PointCloud<PointXYZIL>::Ptr pc(new pcl::PointCloud<PointXYZIL>());
+  int wall_length = 20;
+  // Wall at right angles to the first principal component of particles
+  buildWall(pc, 0, wall_length);
+  // Wall parallel to the first principal component of particles
+  buildWall(pc, M_PI / 2, wall_length);
+
+  const double robot_yaw = M_PI / 6;
+  const State6DOF mean(mcl_3dl::Vec3(3.5, -5.0, 0), mcl_3dl::Quat(mcl_3dl::Vec3(0, 0, 1), robot_yaw));
+  const std::vector<State6DOF> cov_matrix = buildPoseCovarianceMatrix(robot_yaw, 1.0, 0.2);
+
+  // Fix random seeds to avoid flaky results
+  const std::vector<unsigned int> seeds =
+      {
+          12345,
+          23456,
+          34567,
+          45678,
+          56789,
+      };
+
+  struct ParameterSet
+  {
+    double perform_weighting_ratio;
+    double max_weight_ratio;
+    double max_weight;
+    double expected_ratio_min;
+    double expected_ratio_max;
+  };
+  const std::vector<ParameterSet> parameters =
+      {
+          // Weights of points in the wall at right angles: 10, weights of points in the parallel wall: 1
+          {2.0, 4.0, 10.0, 0.9, 1.0},  // NOLINT(whitespace/braces)
+          // Weights of points in the wall at right angles: 1, weights of points in the parallel wall: 1
+          {6.0, 7.0, 10.0, 0.45, 0.55},  // NOLINT(whitespace/braces)
+          // Weights of points in the wall at right angles: 3, weights of points in the parallel wall: 1
+          {2.0, 8.0, 5.0, 0.7, 0.8},  // NOLINT(whitespace/braces)
+      };
+
+  for (const unsigned int seed : seeds)
+  {
+    PointCloudSamplerWithNormal<PointXYZIL> sampler(seed);
+    sampler.setParticleStatistics(mean, cov_matrix);
+    const int sample_num = 100;
+    for (const ParameterSet& parameter : parameters)
+    {
+      sampler.setParameters(parameter.perform_weighting_ratio, parameter.max_weight_ratio, parameter.max_weight, 0.4);
+      const pcl::PointCloud<PointXYZIL>::Ptr extracted_cloud = sampler.sample(pc, sample_num);
+      EXPECT_EQ(sample_num, extracted_cloud->size());
+      // count[0] : numbers of points chosen from the wall at right angles
+      // count[1] : numbers of points chosen from the parallel wall
+      std::vector<int> counts(2, 0);
+      for (const auto& extracted_point : *extracted_cloud)
+      {
+        const auto pred = [&extracted_point](const PointXYZIL& p) {  // NOLINT(whitespace/braces)
+          return (p.x == extracted_point.x) && (p.y == extracted_point.y) && (p.z == extracted_point.z);
+        };
+        const size_t index = std::find_if(pc->begin(), pc->end(), pred) - pc->begin();
+        ++counts[index / std::pow(wall_length, 2)];
+      }
+      const double ratio = static_cast<double>(counts[0]) / (counts[0] + counts[1]);
+      EXPECT_GE(ratio, parameter.expected_ratio_min);
+      EXPECT_LE(ratio, parameter.expected_ratio_max);
+    }
+  }
+
+  PointCloudSamplerWithNormal<PointXYZIL> sampler;
+  sampler.setParticleStatistics(mean, cov_matrix);
+  pcl::PointCloud<PointXYZIL>::Ptr invalid_cloud(new pcl::PointCloud<PointXYZIL>());
+  // Empty cloud
+  EXPECT_EQ(0, sampler.sample(invalid_cloud, 100)->size());
+  // Point cloud size is smaller than requested sample number
+  invalid_cloud->push_back(PointXYZIL());
+  EXPECT_EQ(1, sampler.sample(invalid_cloud, 100)->size());
+}
+}  // namespace test
+}  // namespace mcl_3dl
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
When the first principal component of particle positions are much larger than the second, PointCloudSamplerWithNormal selectively samples scan points that have small angular difference between their normals and the first principal component.
After a robot moves along a long corridor without features to estimate travel distance, particles can be converged quickly with this algorithm soon after the robot finds a side way.