### PR TITLE
Fix crushing when new map is received

### DIFF
--- a/include/mcl_3dl/raycasts/raycast_using_dda.h
+++ b/include/mcl_3dl/raycasts/raycast_using_dda.h
@@ -185,7 +185,8 @@ private:
     }
 
     points_.clear();
-    point_exists_.resize(point_total, 0);
+    point_exists_.resize(point_total);
+    std::fill(point_exists_.begin(), point_exists_.end(), 0);
     for (const auto& p : *input)
     {
       setExists(&p);

--- a/src/mcl_3dl.cpp
+++ b/src/mcl_3dl.cpp
@@ -133,10 +133,10 @@ protected:
       has_map_ = false;
       return;
     }
+    const ros::Time map_stamp = (msg->header.stamp != ros::Time()) ? msg->header.stamp : ros::Time::now();
+    pcl_conversions::toPCL(map_stamp, pc_tmp->header.stamp);
 
     pc_map_.reset(new pcl::PointCloud<PointType>);
-    const ros::Time map_stamp = msg->header.stamp.isValid() ? msg->header.stamp : ros::Time::now();
-    pcl_conversions::toPCL(map_stamp, pc_map_->header.stamp);
     pc_map2_.reset();
     pc_update_.reset();
     pcl::VoxelGrid18<PointType> ds;


### PR DESCRIPTION
- As `resize()` does not overwrite existing values, it is needed to call `std::fill()`.
- Timestamp should be added to `pc_tmp` instead of `pc_map_` as the header of `pc_map_` is overwritten by the header of `pc_tmp` in `ds.filter(*pc_map_)`.
- On my laptop(Ubuntu 16.04, kinetic), `msg->header.stamp.isValid()` returns true even when it is 0. 