### PR TITLE
Fix reported entropy

### DIFF
--- a/include/mcl_3dl/pf.h
+++ b/include/mcl_3dl/pf.h
@@ -256,10 +256,13 @@ public:
     }
     if (sum > 0.0)
     {
+      entropy_ = 0;
       for (auto& p : particles_)
       {
         p.probability_ /= sum;
+        entropy_ += p.probability_ * std::log(p.probability_);
       }
+      entropy_ *= -1;
     }
     else
     {

--- a/include/mcl_3dl/pf.h
+++ b/include/mcl_3dl/pf.h
@@ -437,12 +437,17 @@ public:
   {
     return particles_.end();
   }
+  FLT_TYPE getEntropy() const
+  {
+    return entropy_;
+  }
 
 protected:
   std::vector<Particle<T, FLT_TYPE>> particles_;
   std::vector<Particle<T, FLT_TYPE>> particles_dup_;
   RANDOM_ENGINE engine_;
   T ie_;
+  FLT_TYPE entropy_;
 };
 
 }  // namespace pf

--- a/include/mcl_3dl/pf.h
+++ b/include/mcl_3dl/pf.h
@@ -260,7 +260,10 @@ public:
       for (auto& p : particles_)
       {
         p.probability_ /= sum;
-        entropy_ += p.probability_ * std::log(p.probability_);
+        if (p.probability_ > 0)
+        {
+          entropy_ += p.probability_ * std::log(p.probability_);
+        }
       }
       entropy_ *= -1;
     }

--- a/src/mcl_3dl.cpp
+++ b/src/mcl_3dl.cpp
@@ -1119,25 +1119,8 @@ protected:
       pm.orientation.w = p.rot_.w_;
       pa.poses.push_back(pm);
     }
+
     pub_particle_.publish(pa);
-  }
-
-  float getEntropy()
-  {
-    float sum = 0.0f;
-    for (auto& particle : *pf_)
-    {
-      sum += particle.probability_;
-    }
-
-    float entropy = 0.0f;
-    for (auto& particle : *pf_)
-    {
-      if (particle.probability_ / sum > 0.0)
-        entropy += particle.probability_ / sum * std::log(particle.probability_ / sum);
-    }
-
-    return -entropy;
   }
 
   void diagnoseStatus(diagnostic_updater::DiagnosticStatusWrapper& stat)
@@ -1159,7 +1142,7 @@ protected:
     stat.add("Odometry Availability", has_odom_ ? "true" : "false");
     stat.add("IMU Availability", has_imu_ ? "true" : "false");
 
-    status_.entropy = getEntropy();
+    status_.entropy = pf_->getEntropy();
     pub_status_.publish(status_);
   }
 


### PR DESCRIPTION
With the current implementation on the `master` branch, the entropy of the particle filter seems to be always calculated after resampling or resizing the number of particles which reset each particle probability to `1 / num_particles`. Thus the reported entropy is always the same. In this PR, this quantity is calculated in the `measure` function to represent the entropy of the particle filter right after the particles probabilities are updated based on the measurement likelihood.  