### PR TITLE
Fix angular part of covariance matrix

### DIFF
--- a/include/mcl_3dl/pf.h
+++ b/include/mcl_3dl/pf.h
@@ -80,6 +80,10 @@ public:
     }
     return noise;
   }
+  virtual size_t covDimension() const
+  {
+    return size();
+  }
 };
 
 template <typename T, typename FLT_TYPE = float>
@@ -303,8 +307,6 @@ public:
   {
     T e = expectation(pass_ratio);
     FLT_TYPE p_sum = 0;
-    std::vector<T> cov;
-    cov.resize(e.size());
 
     size_t p_num = 0;
     for (auto& p : particles_)
@@ -330,22 +332,25 @@ public:
       indices.resize(sample_num);
     }
 
+    std::vector<T> cov;
+    cov.resize(ie_.covDimension());
+
     p_sum = 0.0;
     for (size_t i : indices)
     {
       auto& p = particles_[i];
       p_sum += p.probability_;
-      for (size_t j = 0; j < ie_.size(); j++)
+      for (size_t j = 0; j < ie_.covDimension(); j++)
       {
-        for (size_t k = j; k < ie_.size(); k++)
+        for (size_t k = j; k < ie_.covDimension(); k++)
         {
           cov[k][j] = cov[j][k] += p.state_.covElement(e, j, k) * p.probability_;
         }
       }
     }
-    for (size_t j = 0; j < ie_.size(); j++)
+    for (size_t j = 0; j < ie_.covDimension(); j++)
     {
-      for (size_t k = 0; k < ie_.size(); k++)
+      for (size_t k = 0; k < ie_.covDimension(); k++)
       {
         cov[k][j] /= p_sum;
       }

--- a/include/mcl_3dl/state_6dof.h
+++ b/include/mcl_3dl/state_6dof.h
@@ -161,15 +161,14 @@ public:
   }
   float covElement(const State6DOF& e, const size_t& j, const size_t& k)
   {
-    const State6DOF exp = e;
-    const mcl_3dl::Vec3 exp_rpy = exp.isDiff() ? exp.rpy_.v_ : exp.rot_.getRPY();
+    const mcl_3dl::Vec3 exp_rpy = e.isDiff() ? e.rpy_.v_ : e.rot_.getRPY();
     const mcl_3dl::Vec3 rpy = isDiff() ? rpy_.v_ : rot_.getRPY();
     float val = 1.0f, diff = 0.0f;
     for (size_t i : {j, k})
     {
       if (i < 3)
       {
-        diff = (*this)[i] - exp[i];
+        diff = (*this)[i] - e[i];
       }
       else
       {

--- a/include/mcl_3dl/state_6dof.h
+++ b/include/mcl_3dl/state_6dof.h
@@ -159,6 +159,30 @@ public:
   {
     return 6;
   }
+  float covElement(const State6DOF& e, const size_t& j, const size_t& k)
+  {
+    const State6DOF exp = e;
+    const mcl_3dl::Vec3 exp_rpy = exp.isDiff() ? exp.rpy_.v_ : exp.rot_.getRPY();
+    const mcl_3dl::Vec3 rpy = isDiff() ? rpy_.v_ : rot_.getRPY();
+    float val = 1.0f, diff = 0.0f;
+    for (size_t i : {j, k})
+    {
+      if (i < 3)
+      {
+        diff = (*this)[i] - exp[i];
+      }
+      else
+      {
+        diff = rpy[i - 3] - exp_rpy[i - 3];
+        while (diff > M_PI)
+          diff -= 2 * M_PI;
+        while (diff < -M_PI)
+          diff += 2 * M_PI;
+      }
+      val *= diff;
+    }
+    return val;
+  }
   State6DOF()
   {
     diff_ = false;

--- a/include/mcl_3dl/state_6dof.h
+++ b/include/mcl_3dl/state_6dof.h
@@ -155,6 +155,10 @@ public:
   {
     rot_.normalize();
   }
+  size_t covDimension() const override
+  {
+    return 6;
+  }
   State6DOF()
   {
     diff_ = false;

--- a/src/mcl_3dl.cpp
+++ b/src/mcl_3dl.cpp
@@ -727,9 +727,9 @@ protected:
 
     if (!global_localization_fix_cnt_)
     {
-      if (std::sqrt(cov[0][0] + cov[1][1]) > params_.std_warn_thresh_[0] ||
-          std::sqrt(cov[2][2]) > params_.std_warn_thresh_[1] ||
-          std::sqrt(cov[5][5]) > params_.std_warn_thresh_[2])
+      if (std::sqrt(pose.pose.covariance[0] + pose.pose.covariance[7]) > params_.std_warn_thresh_[0] ||
+          std::sqrt(pose.pose.covariance[14]) > params_.std_warn_thresh_[1] ||
+          std::sqrt(pose.pose.covariance[35]) > params_.std_warn_thresh_[2])
       {
         status_.convergence_status = mcl_3dl_msgs::Status::CONVERGENCE_STATUS_LARGE_STD_VALUE;
       }
@@ -738,8 +738,8 @@ protected:
     if (status_.convergence_status != mcl_3dl_msgs::Status::CONVERGENCE_STATUS_LARGE_STD_VALUE)
     {
       Vec3 fix_axis;
-      const float fix_ang = std::sqrt(cov[3][3] + cov[4][4] + cov[5][5]);
-      const float fix_dist = std::sqrt(cov[0][0] + cov[1][1] + cov[2][2]);
+      const float fix_ang = std::sqrt(pose.pose.covariance[21] + pose.pose.covariance[28] + pose.pose.covariance[35]);
+      const float fix_dist = std::sqrt(pose.pose.covariance[0] + pose.pose.covariance[7] + pose.pose.covariance[14]);
       ROS_DEBUG("cov: lin %0.3f ang %0.3f", fix_dist, fix_ang);
       if (fix_dist < params_.fix_dist_ &&
           fabs(fix_ang) < params_.fix_ang_)

--- a/src/mcl_3dl.cpp
+++ b/src/mcl_3dl.cpp
@@ -727,9 +727,9 @@ protected:
 
     if (!global_localization_fix_cnt_)
     {
-      if (std::sqrt(pose.pose.covariance[0] + pose.pose.covariance[7]) > params_.std_warn_thresh_[0] ||
-          std::sqrt(pose.pose.covariance[14]) > params_.std_warn_thresh_[1] ||
-          std::sqrt(pose.pose.covariance[35]) > params_.std_warn_thresh_[2])
+      if (std::sqrt(pose.pose.covariance[0] + pose.pose.covariance[1 * 6 + 1]) > params_.std_warn_thresh_[0] ||
+          std::sqrt(pose.pose.covariance[2 * 6 + 2]) > params_.std_warn_thresh_[1] ||
+          std::sqrt(pose.pose.covariance[5 * 6 + 5]) > params_.std_warn_thresh_[2])
       {
         status_.convergence_status = mcl_3dl_msgs::Status::CONVERGENCE_STATUS_LARGE_STD_VALUE;
       }
@@ -738,8 +738,10 @@ protected:
     if (status_.convergence_status != mcl_3dl_msgs::Status::CONVERGENCE_STATUS_LARGE_STD_VALUE)
     {
       Vec3 fix_axis;
-      const float fix_ang = std::sqrt(pose.pose.covariance[21] + pose.pose.covariance[28] + pose.pose.covariance[35]);
-      const float fix_dist = std::sqrt(pose.pose.covariance[0] + pose.pose.covariance[7] + pose.pose.covariance[14]);
+      const float fix_ang = std::sqrt(
+          pose.pose.covariance[3 * 6 + 3] + pose.pose.covariance[4 * 6 + 4] + pose.pose.covariance[5 * 6 + 5]);
+      const float fix_dist = std::sqrt(
+          pose.pose.covariance[0] + pose.pose.covariance[1 * 6 + 1] + pose.pose.covariance[2 * 6 + 2]);
       ROS_DEBUG("cov: lin %0.3f ang %0.3f", fix_dist, fix_ang);
       if (fix_dist < params_.fix_dist_ &&
           fabs(fix_ang) < params_.fix_ang_)

--- a/src/mcl_3dl.cpp
+++ b/src/mcl_3dl.cpp
@@ -704,7 +704,7 @@ protected:
 
     // Calculate covariance from sampled particles to reduce calculation cost on global localization.
     // Use the number of original particles or at least 10% of full particles.
-    auto cov = pf_->covariance(
+    const auto cov = pf_->covariance(
         1.0,
         std::max(
             0.1f, static_cast<float>(params_.num_particles_) / pf_->getParticleSize()));

--- a/test/src/test_state_6dof.cpp
+++ b/test/src/test_state_6dof.cpp
@@ -126,12 +126,24 @@ TEST(State6DOF, CovarianceMatrix)
   std::normal_distribution<float> z_dis(e.pos_.z_, 0.3);
   std::normal_distribution<float> yaw_dis(e.rot_.getRPY().z_, 0.4);
 
+  const auto generate_state = [&mt, &x_dis, &y_dis, &z_dis, &yaw_dis](const bool use_rpy) -> mcl_3dl::State6DOF
+  {
+    if (use_rpy)
+    {
+      return mcl_3dl::State6DOF(mcl_3dl::Vec3(x_dis(mt), y_dis(mt), z_dis(mt)),
+                                mcl_3dl::Vec3(0, 0, yaw_dis(mt)));
+    }
+    else
+    {
+      return mcl_3dl::State6DOF(mcl_3dl::Vec3(x_dis(mt), y_dis(mt), z_dis(mt)),
+                                mcl_3dl::Quat(mcl_3dl::Vec3(0.0, 0.0, 1.0), yaw_dis(mt)));
+    }
+  };
+
   const std::size_t N = 500;
   for (std::size_t n = 0; n < N; n++)
   {
-    mcl_3dl::State6DOF s(
-        mcl_3dl::Vec3(x_dis(mt), y_dis(mt), z_dis(mt)),
-        mcl_3dl::Quat(mcl_3dl::Vec3(0.0, 0.0, 1.0), yaw_dis(mt)));
+    mcl_3dl::State6DOF s = generate_state(n % 2 == 0);
     for (std::size_t j = 0; j < 6; j++)
     {
       for (std::size_t k = j; k < 6; k++)


### PR DESCRIPTION
In https://github.com/at-wat/mcl_3dl/blob/361a57f6c0ae5b1797f52827856f7829d6c9f0d2/src/mcl_3dl.cpp#L707-L750, `cov` is a `13x13` matrix which contains the covariance information about the 3D position and the orientation in quaternion (top left `7x7` sub matrix from `cov`) but it is used as a `6x6` matrix representing the covariance of the 3D position and the orientation in Euler angles (roll pitch yaw). Thus the covariance matrix reported in `/amcl_pose` is incorrect as well as the subsequent checks on `cov` e.g. cov[5][5] does not represent to variance of yaw. To fix this issue, the covariance matrix calculations are now done using the Euler angles directly rather than quaternion by overriding `covElement` in `State6DOF`.