### PR TITLE
Fix MCL_3DL_EXTRA_TESTS environment variable check in if condition

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,7 +108,7 @@ add_rostest_gtest(test_transform_failure tests/transform_rostest.test
 target_link_libraries(test_transform_failure ${catkin_LIBRARIES})
 add_dependencies(test_transform_failure mcl_3dl)
 
-if(MCL_3DL_EXTRA_TESTS OR $ENV{MCL_3DL_EXTRA_TESTS})
+if(MCL_3DL_EXTRA_TESTS OR "$ENV{MCL_3DL_EXTRA_TESTS}" STREQUAL "ON")
 
   catkin_download_test_data(
       ${PROJECT_NAME}_short_test3.bag


### PR DESCRIPTION
This PR fixes the following issue when trying to run `catkin_make` without `MCL_3DL_EXTRA_TESTS` environment variable being set

```
-- Found Boost: /usr/include (found version "1.71.0") found components: chrono 
CMake Error at mcl_3dl/test/CMakeLists.txt:111 (if):
  if given arguments:

    "MCL_3DL_EXTRA_TESTS" "OR"

  Unknown arguments specified


-- Configuring incomplete, errors occurred!
```