### PR TITLE
Share sampler between lidar measurement methods

### DIFF
--- a/include/mcl_3dl/lidar_measurement_model_base.h
+++ b/include/mcl_3dl/lidar_measurement_model_base.h
@@ -10,8 +10,8 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the copyright holder nor the names of its 
- *       contributors may be used to endorse or promote products derived from 
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
@@ -42,7 +42,6 @@
 
 #include <mcl_3dl/chunked_kdtree.h>
 #include <mcl_3dl/point_cloud_random_sampler.h>
-#include <mcl_3dl/point_cloud_random_samplers/point_cloud_uniform_sampler.h>
 #include <mcl_3dl/point_types.h>
 #include <mcl_3dl/state_6dof.h>
 #include <mcl_3dl/vec3.h>
@@ -66,10 +65,8 @@ class LidarMeasurementModelBase
 public:
   using Ptr = std::shared_ptr<LidarMeasurementModelBase>;
   using PointType = mcl_3dl::PointXYZIL;
-  using SamplerType = PointCloudRandomSampler<PointType>;
 
   LidarMeasurementModelBase()
-    : sampler_(new PointCloudUniformSampler<PointType>())
   {
   }
 
@@ -79,27 +76,15 @@ public:
   virtual void setGlobalLocalizationStatus(
       const size_t, const size_t) = 0;
   virtual float getMaxSearchRange() const = 0;
-
   virtual pcl::PointCloud<PointType>::Ptr filter(
-      const pcl::PointCloud<PointType>::ConstPtr&) const = 0;
+      const pcl::PointCloud<PointType>::ConstPtr&,
+      const PointCloudRandomSampler<PointType>&) const = 0;
 
   virtual LidarMeasurementResult measure(
       ChunkedKdtree<PointType>::Ptr&,
       const pcl::PointCloud<PointType>::ConstPtr&,
       const std::vector<Vec3>&,
       const State6DOF&) const = 0;
-
-  void setRandomSampler(const std::shared_ptr<SamplerType>& sampler)
-  {
-    sampler_ = sampler;
-  }
-  std::shared_ptr<SamplerType> getRandomSampler()
-  {
-    return sampler_;
-  }
-
-protected:
-  std::shared_ptr<SamplerType> sampler_;
 };
 }  // namespace mcl_3dl
 

--- a/include/mcl_3dl/lidar_measurement_models/lidar_measurement_model_beam.h
+++ b/include/mcl_3dl/lidar_measurement_models/lidar_measurement_model_beam.h
@@ -100,7 +100,8 @@ public:
       const size_t num_particles,
       const size_t current_num_particles);
   pcl::PointCloud<PointType>::Ptr filter(
-      const pcl::PointCloud<PointType>::ConstPtr& pc) const;
+      const pcl::PointCloud<PointType>::ConstPtr& pc,
+      const PointCloudRandomSampler<PointType>& sampler) const;
   LidarMeasurementResult measure(
       ChunkedKdtree<PointType>::Ptr& kdtree,
       const pcl::PointCloud<PointType>::ConstPtr& pc,

--- a/include/mcl_3dl/lidar_measurement_models/lidar_measurement_model_likelihood.h
+++ b/include/mcl_3dl/lidar_measurement_models/lidar_measurement_model_likelihood.h
@@ -74,7 +74,8 @@ public:
       const size_t num_particles,
       const size_t current_num_particles);
   pcl::PointCloud<PointType>::Ptr filter(
-      const pcl::PointCloud<PointType>::ConstPtr& pc) const;
+      const pcl::PointCloud<PointType>::ConstPtr& pc,
+      const PointCloudRandomSampler<PointType>& sampler) const;
   LidarMeasurementResult measure(
       ChunkedKdtree<PointType>::Ptr& kdtree,
       const pcl::PointCloud<PointType>::ConstPtr& pc,

--- a/include/mcl_3dl/point_cloud_random_sampler.h
+++ b/include/mcl_3dl/point_cloud_random_sampler.h
@@ -43,11 +43,15 @@ template <class POINT_TYPE>
 class PointCloudRandomSampler
 {
 public:
-  virtual void loadConfig(const ros::NodeHandle& nh) {};
+  virtual void loadConfig(const ros::NodeHandle& nh)
+  {
+  }
   virtual typename pcl::PointCloud<POINT_TYPE>::Ptr sample(
       const typename pcl::PointCloud<POINT_TYPE>::ConstPtr& pc, const size_t num) const = 0;
   virtual void setParticleStatistics(
-      const State6DOF& mean, const std::vector<State6DOF>& covariances) {};
+      const State6DOF& mean, const std::vector<State6DOF>& covariances)
+  {
+  }
 };
 
 }  // namespace mcl_3dl

--- a/include/mcl_3dl/point_cloud_random_sampler.h
+++ b/include/mcl_3dl/point_cloud_random_sampler.h
@@ -10,8 +10,8 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the copyright holder nor the names of its 
- *       contributors may be used to endorse or promote products derived from 
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
@@ -30,6 +30,8 @@
 #ifndef MCL_3DL_POINT_CLOUD_RANDOM_SAMPLER_H
 #define MCL_3DL_POINT_CLOUD_RANDOM_SAMPLER_H
 
+#include <vector>
+
 #include <pcl/point_cloud.h>
 
 #include <mcl_3dl/chunked_kdtree.h>
@@ -45,8 +47,7 @@ public:
   virtual typename pcl::PointCloud<POINT_TYPE>::Ptr sample(
       const typename pcl::PointCloud<POINT_TYPE>::ConstPtr& pc, const size_t num) const = 0;
   virtual void setParticleStatistics(
-    const State6DOF& mean, const std::vector<State6DOF>& covariances) = 0;
-
+      const State6DOF& mean, const std::vector<State6DOF>& covariances) = 0;
 };
 
 }  // namespace mcl_3dl

--- a/include/mcl_3dl/point_cloud_random_sampler.h
+++ b/include/mcl_3dl/point_cloud_random_sampler.h
@@ -33,6 +33,7 @@
 #include <pcl/point_cloud.h>
 
 #include <mcl_3dl/chunked_kdtree.h>
+#include <mcl_3dl/state_6dof.h>
 
 namespace mcl_3dl
 {
@@ -40,8 +41,12 @@ template <class POINT_TYPE>
 class PointCloudRandomSampler
 {
 public:
+  virtual void loadConfig(const ros::NodeHandle& nh) = 0;
   virtual typename pcl::PointCloud<POINT_TYPE>::Ptr sample(
       const typename pcl::PointCloud<POINT_TYPE>::ConstPtr& pc, const size_t num) const = 0;
+  virtual void setParticleStatistics(
+    const State6DOF& mean, const std::vector<State6DOF>& covariances) = 0;
+
 };
 
 }  // namespace mcl_3dl

--- a/include/mcl_3dl/point_cloud_random_sampler.h
+++ b/include/mcl_3dl/point_cloud_random_sampler.h
@@ -43,11 +43,11 @@ template <class POINT_TYPE>
 class PointCloudRandomSampler
 {
 public:
-  virtual void loadConfig(const ros::NodeHandle& nh) = 0;
+  virtual void loadConfig(const ros::NodeHandle& nh) {};
   virtual typename pcl::PointCloud<POINT_TYPE>::Ptr sample(
       const typename pcl::PointCloud<POINT_TYPE>::ConstPtr& pc, const size_t num) const = 0;
   virtual void setParticleStatistics(
-      const State6DOF& mean, const std::vector<State6DOF>& covariances) = 0;
+      const State6DOF& mean, const std::vector<State6DOF>& covariances) {};
 };
 
 }  // namespace mcl_3dl

--- a/include/mcl_3dl/point_cloud_random_sampler.h
+++ b/include/mcl_3dl/point_cloud_random_sampler.h
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include <pcl/point_cloud.h>
+#include <ros/ros.h>
 
 #include <mcl_3dl/chunked_kdtree.h>
 #include <mcl_3dl/state_6dof.h>

--- a/include/mcl_3dl/point_cloud_random_samplers/point_cloud_sampler_with_normal.h
+++ b/include/mcl_3dl/point_cloud_random_samplers/point_cloud_sampler_with_normal.h
@@ -75,7 +75,7 @@ public:
   {
   }
 
-  void loadConfig(const ros::NodeHandle& nh)
+  void loadConfig(const ros::NodeHandle& nh) final
   {
     ros::NodeHandle pnh(nh, "random_sampler_with_normal");
     pnh.param("perform_weighting_ratio", perform_weighting_ratio_, 2.0);
@@ -93,7 +93,7 @@ public:
     normal_search_range_ = normal_search_range;
   }
 
-  void setParticleStatistics(const State6DOF& mean, const std::vector<State6DOF>& covariances)
+  void setParticleStatistics(const State6DOF& mean, const std::vector<State6DOF>& covariances) final
   {
     mean_ = mean;
     Matrix pos_cov(3, 3);

--- a/include/mcl_3dl/point_cloud_random_samplers/point_cloud_uniform_sampler.h
+++ b/include/mcl_3dl/point_cloud_random_samplers/point_cloud_uniform_sampler.h
@@ -53,14 +53,6 @@ public:
   {
   }
 
-  void loadConfig(const ros::NodeHandle& nh) final
-  {
-  }
-
-  void setParticleStatistics(const State6DOF& mean, const std::vector<State6DOF>& covariances) final
-  {
-  }
-
   typename pcl::PointCloud<POINT_TYPE>::Ptr sample(
       const typename pcl::PointCloud<POINT_TYPE>::ConstPtr& pc,
       const size_t num) const final

--- a/include/mcl_3dl/point_cloud_random_samplers/point_cloud_uniform_sampler.h
+++ b/include/mcl_3dl/point_cloud_random_samplers/point_cloud_uniform_sampler.h
@@ -10,8 +10,8 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the copyright holder nor the names of its 
- *       contributors may be used to endorse or promote products derived from 
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
@@ -51,6 +51,15 @@ public:
     : engine_(new std::default_random_engine(seed_gen_()))
   {
   }
+
+  void loadConfig(const ros::NodeHandle& nh) final
+  {
+  }
+
+  void setParticleStatistics(const State6DOF& mean, const std::vector<State6DOF>& covariances) final
+  {
+  }
+
   typename pcl::PointCloud<POINT_TYPE>::Ptr sample(
       const typename pcl::PointCloud<POINT_TYPE>::ConstPtr& pc,
       const size_t num) const final

--- a/include/mcl_3dl/point_cloud_random_samplers/point_cloud_uniform_sampler.h
+++ b/include/mcl_3dl/point_cloud_random_samplers/point_cloud_uniform_sampler.h
@@ -32,6 +32,7 @@
 
 #include <memory>
 #include <random>
+#include <vector>
 
 #include <pcl/point_cloud.h>
 

--- a/src/lidar_measurement_model_beam.cpp
+++ b/src/lidar_measurement_model_beam.cpp
@@ -143,7 +143,8 @@ void LidarMeasurementModelBeam::setGlobalLocalizationStatus(
 
 typename pcl::PointCloud<LidarMeasurementModelBase::PointType>::Ptr
 LidarMeasurementModelBeam::filter(
-    const typename pcl::PointCloud<LidarMeasurementModelBase::PointType>::ConstPtr& pc) const
+    const typename pcl::PointCloud<LidarMeasurementModelBase::PointType>::ConstPtr& pc,
+    const PointCloudRandomSampler<PointType>& sampler) const
 {
   const auto local_points_filter = [this](const LidarMeasurementModelBase::PointType& p)
   {
@@ -163,7 +164,7 @@ LidarMeasurementModelBeam::filter(
   pc_filtered->width = 1;
   pc_filtered->height = pc_filtered->points.size();
 
-  return sampler_->sample(pc_filtered, num_points_);
+  return sampler.sample(pc_filtered, num_points_);
 }
 
 LidarMeasurementResult LidarMeasurementModelBeam::measure(

--- a/src/lidar_measurement_model_likelihood.cpp
+++ b/src/lidar_measurement_model_likelihood.cpp
@@ -10,8 +10,8 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the copyright holder nor the names of its 
- *       contributors may be used to endorse or promote products derived from 
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
@@ -98,7 +98,8 @@ void LidarMeasurementModelLikelihood::setGlobalLocalizationStatus(
 
 typename pcl::PointCloud<LidarMeasurementModelBase::PointType>::Ptr
 LidarMeasurementModelLikelihood::filter(
-    const typename pcl::PointCloud<LidarMeasurementModelBase::PointType>::ConstPtr& pc) const
+    const typename pcl::PointCloud<LidarMeasurementModelBase::PointType>::ConstPtr& pc,
+    const PointCloudRandomSampler<PointType>& sampler) const
 {
   const auto local_points_filter = [this](const LidarMeasurementModelBase::PointType& p)
   {
@@ -118,7 +119,7 @@ LidarMeasurementModelLikelihood::filter(
   pc_filtered->width = 1;
   pc_filtered->height = pc_filtered->points.size();
 
-  return sampler_->sample(pc_filtered, num_points_);
+  return sampler.sample(pc_filtered, num_points_);
 }
 
 LidarMeasurementResult LidarMeasurementModelLikelihood::measure(


### PR DESCRIPTION
This PR refactors the `PointCloudRandomSampler` and `LidarMeasurementModelBase` classes to do the following:
- Create only one instance of `PointCloudRandomSampler`
- Pass it as an argument to the `filter` method instead of using it as a class member of  `LidarMeasurementModelBase`
-  Add `loadConfig` and `setParticleStatistics` as virtual methods of `PointCloudRandomSampler` so that there is no need for casting the `sampler` object.