### PR TITLE
Standard deviation warning thresholds as dynamic parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CATKIN_DEPENDS
   tf2_sensor_msgs
 
   diagnostic_updater
+  dynamic_reconfigure
   geometry_msgs
   mcl_3dl_msgs
   nav_msgs
@@ -29,6 +30,11 @@ find_package(PCL 1.8.0 REQUIRED
     kdtree
 )
 find_package(Boost REQUIRED COMPONENTS chrono)
+
+generate_dynamic_reconfigure_options(
+  cfg/MCL3DLParams.cfg
+)
+
 catkin_package(
   INCLUDE_DIRS include
   CATKIN_DEPENDS ${CATKIN_DEPENDS}

--- a/cfg/MCL3DLParams.cfg
+++ b/cfg/MCL3DLParams.cfg
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+import sys
+
+from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, double_t
+
+gen = ParameterGenerator()
+
+gen.add(
+    "std_warn_thresh_xy",
+    double_t,
+    0,
+    "Warning threshold for the XY position uncertainty",
+    sys.float_info.max,
+    0,
+    sys.float_info.max,
+)
+gen.add(
+    "std_warn_thresh_z",
+    double_t,
+    0,
+    "Warning threshold for position Z coordinate uncertainty",
+    sys.float_info.max,
+    0,
+    sys.float_info.max,
+)
+gen.add(
+    "std_warn_thresh_yaw",
+    double_t,
+    0,
+    "Warning threshold for yaw orientation uncertainty",
+    sys.float_info.max,
+    0,
+    sys.float_info.max,
+)
+
+
+PACKAGE = "mcl_3dl"
+exit(gen.generate(PACKAGE, "mcl_3dl", "MCL3DLParams"))

--- a/include/mcl_3dl/parameters.h
+++ b/include/mcl_3dl/parameters.h
@@ -34,8 +34,10 @@
 #include <memory>
 #include <string>
 
+#include <dynamic_reconfigure/server.h>
 #include <ros/ros.h>
 
+#include <mcl_3dl/MCL3DLParamsConfig.h>
 #include <mcl_3dl/quat.h>
 #include <mcl_3dl/state_6dof.h>
 #include <mcl_3dl/vec3.h>
@@ -200,6 +202,10 @@ public:
   std::shared_ptr<PointCloudSamplerWithNormalParameters> random_sampler_with_normal_params_;
   std::shared_ptr<LidarMeasurementModelLikelihoodParameters> lidar_measurement_likelihood_params_;
   std::shared_ptr<LidarMeasurementModelBeamParameters> lidar_measurement_beam_params_;
+
+private:
+  std::unique_ptr<dynamic_reconfigure::Server<MCL3DLParamsConfig>> parameter_server_;
+  void cbParameter(const MCL3DLParamsConfig& config, const uint32_t /* level */);
 };
 }  // namespace mcl_3dl
 

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <test_depend>rosunit</test_depend>
 
   <depend>diagnostic_updater</depend>
+  <depend>dynamic_reconfigure</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>pcl_ros</depend>

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -33,10 +33,11 @@
 #include <memory>
 #include <string>
 
+#include <dynamic_reconfigure/server.h>
 #include <ros/ros.h>
 
+#include <mcl_3dl/MCL3DLParamsConfig.h>
 #include <mcl_3dl/parameters.h>
-
 #include <mcl_3dl_compat/compatibility.h>
 
 namespace mcl_3dl
@@ -308,6 +309,16 @@ bool Parameters::load(ros::NodeHandle& pnh)
       lidar_measurement_beam_params_->dda_grid_size_ = dda_grid_size;
     }
   }
+
+  parameter_server_.reset(new dynamic_reconfigure::Server<MCL3DLParamsConfig>(pnh));
+  parameter_server_->setCallback(
+      boost::bind(&Parameters::cbParameter, this, boost::placeholders::_1, boost::placeholders::_2));
+
   return true;
 }
+
+void Parameters::cbParameter(const MCL3DLParamsConfig& config, const uint32_t /* level */)
+{
+}
+
 }  // namespace mcl_3dl

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -319,6 +319,9 @@ bool Parameters::load(ros::NodeHandle& pnh)
 
 void Parameters::cbParameter(const MCL3DLParamsConfig& config, const uint32_t /* level */)
 {
+  std_warn_thresh_[0] = config.std_warn_thresh_xy;
+  std_warn_thresh_[1] = config.std_warn_thresh_z;
+  std_warn_thresh_[2] = config.std_warn_thresh_yaw;
 }
 
 }  // namespace mcl_3dl

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,6 +108,12 @@ add_rostest_gtest(test_transform_failure tests/transform_rostest.test
 target_link_libraries(test_transform_failure ${catkin_LIBRARIES})
 add_dependencies(test_transform_failure mcl_3dl)
 
+add_rostest_gtest(test_parameters tests/parameters_rostest.test
+    src/test_parameters.cpp
+    ../src/parameters.cpp
+)
+target_link_libraries(test_parameters ${catkin_LIBRARIES})
+
 if(MCL_3DL_EXTRA_TESTS OR "$ENV{MCL_3DL_EXTRA_TESTS}" STREQUAL "ON")
 
   catkin_download_test_data(

--- a/test/src/test_parameters.cpp
+++ b/test/src/test_parameters.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2016-2025, the mcl_3dl authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <dynamic_reconfigure/client.h>
+#include <ros/ros.h>
+
+#include <mcl_3dl/MCL3DLParamsConfig.h>
+#include <mcl_3dl/parameters.h>
+
+TEST(Parameters, DynamicParameters)
+{
+  ros::NodeHandle nh("/mcl_3dl");
+  nh.setParam("std_warn_thresh_xy", 0.1);
+  nh.setParam("std_warn_thresh_z", 0.2);
+  nh.setParam("std_warn_thresh_yaw", 0.3);
+
+  mcl_3dl::Parameters mcl_3dl_params;
+  mcl_3dl_params.load(nh);
+
+  ASSERT_FLOAT_EQ(mcl_3dl_params.std_warn_thresh_[0], 0.1);
+  ASSERT_FLOAT_EQ(mcl_3dl_params.std_warn_thresh_[1], 0.2);
+  ASSERT_FLOAT_EQ(mcl_3dl_params.std_warn_thresh_[2], 0.3);
+
+  std::thread t(
+      []()
+      {
+        dynamic_reconfigure::Client<mcl_3dl::MCL3DLParamsConfig> dynamic_reconfigure_client("/mcl_3dl");
+        mcl_3dl::MCL3DLParamsConfig config;
+        config.std_warn_thresh_xy = 0.5;
+        config.std_warn_thresh_z = 0.6;
+        config.std_warn_thresh_yaw = 0.7;
+
+        while (ros::ok())
+        {
+          // Wait until parameter server becomes ready
+          mcl_3dl::MCL3DLParamsConfig dummy;
+          if (dynamic_reconfigure_client.getCurrentConfiguration(dummy, ros::Duration(0.1)))
+          {
+            break;
+          }
+          ros::spinOnce();
+        }
+        if (!dynamic_reconfigure_client.setConfiguration(config))
+        {
+          FAIL();
+        }
+      });  // NOLINT(whitespace/braces)
+
+  const ros::Time deadline = ros::Time::now() + ros::Duration(0.5);
+  const ros::Duration wait(0.1);
+  while (ros::ok() && ros::Time::now() < deadline)
+  {
+    ros::spinOnce();
+    wait.sleep();
+  }
+  t.join();
+
+  ASSERT_FLOAT_EQ(mcl_3dl_params.std_warn_thresh_[0], 0.5);
+  ASSERT_FLOAT_EQ(mcl_3dl_params.std_warn_thresh_[1], 0.6);
+  ASSERT_FLOAT_EQ(mcl_3dl_params.std_warn_thresh_[2], 0.7);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "test_parameters");
+
+  return RUN_ALL_TESTS();
+}

--- a/test/src/test_parameters.cpp
+++ b/test/src/test_parameters.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <thread>
+#include <thread>  // NOLINT(build/c++11)
 
 #include <gtest/gtest.h>
 

--- a/test/src/test_parameters.cpp
+++ b/test/src/test_parameters.cpp
@@ -68,7 +68,6 @@ TEST(Parameters, DynamicParameters)
           {
             break;
           }
-          ros::spinOnce();
         }
         if (!dynamic_reconfigure_client.setConfiguration(config))
         {

--- a/test/tests/parameters_rostest.test
+++ b/test/tests/parameters_rostest.test
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<launch>
+  <env name="GCOV_PREFIX" value="/tmp/gcov/parameters" />
+
+  <test test-name="test_parameters" pkg="mcl_3dl" type="test_parameters" />
+</launch>

--- a/test/tests/parameters_rostest.test
+++ b/test/tests/parameters_rostest.test
@@ -2,5 +2,5 @@
 <launch>
   <env name="GCOV_PREFIX" value="/tmp/gcov/parameters" />
 
-  <test test-name="test_parameters" pkg="mcl_3dl" type="test_parameters" />
+  <test test-name="test_parameters" pkg="mcl_3dl" type="test_parameters" time-limit="10"/>
 </launch>


### PR DESCRIPTION
This PR adds dynamic reconfigure support for some parameters. For now only the ones about the warning thresholds on the pose uncertainty are available but it should not be too hard to add more parameters in the future if needed.